### PR TITLE
fix api url

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	PorkbunAPIDNSUpdateEndpoint   string = "https://porkbun.com/api/json/v3/dns/editByNameType"
-	PorkbunAPIDNSRetrieveEndpoint string = "https://porkbun.com/api/json/v3/dns/retrieveByNameType"
+	PorkbunAPIDNSUpdateEndpoint   string = "https://api.porkbun.com/api/json/v3/dns/editByNameType"
+	PorkbunAPIDNSRetrieveEndpoint string = "https://api.porkbun.com/api/json/v3/dns/retrieveByNameType"
 	IpifyAPIEndpoint              string = "https://api.ipify.org?format=json"
 )
 


### PR DESCRIPTION
Hello there,

The reason you are receiving this email is because you have an API key associated with your account. In order to ensure that any apps or tools you may have that utilize our API, we wanted to let you know about some upcoming critical updates.

We know these kinds of changes are annoying but the time has come to separate the processing of incoming API commands from our website. In previous documentation the hostname porkbun.com was used for the API but we have recently updated it to api.porkbun.com and in the near future will start enforcing its use. Please update the hostname for our API to api.porkbun.com as soon as possible.


CRITICAL UPDATE DETAILS

Type: API Hostname Change

Old Value: porkbun.com

New Value: api.porkbun.com

Deadline: 2024-12-01 00:00:00 UTC


Please note that after the deadline, API calls made to the old hostname will no longer be allowed. If you have any questions or concerns please contact support.